### PR TITLE
Support unpicklable node function types in RunDir

### DIFF
--- a/apps/RunDir.py
+++ b/apps/RunDir.py
@@ -12,8 +12,9 @@ from   gmn.CLI_Parser   import ParseCmdLine
 from   gmn.ConfigParser import ReadConfig
 
 #-------------------------------------------
-def CallGenerate( GMN ):
+def CallGenerate( args, param ):
     '''Wrapper for GMN.Generate() in multiprocessing Pool'''
+    GMN =  gmn.GMN( args, param )
     GMN.Generate()
 
 #----------------------------------------------------------------------------
@@ -42,11 +43,8 @@ def main():
     # Iterable of parameters for each configFile
     params = [ ReadConfig( args, configurationFile = f ) for f in configFiles ]
 
-    # Iterable of GMN objects
-    gmns = [ gmn.GMN( args, param ) for param in params ]
-
     with Pool( processes = args.cores ) as pool:
-        DataOuts = pool.map( CallGenerate, gmns )
+        DataOuts = pool.starmap( CallGenerate, [ ( args, param ) for param in params ] )
 
 #----------------------------------------------------------------------------
 # Provide for cmd line invocation and clean module loading

--- a/apps/RunDir.py
+++ b/apps/RunDir.py
@@ -2,7 +2,7 @@
 
 # Python distribution modules
 from multiprocessing import set_start_method, Pool
-from os import listdir, walk
+from os import cpu_count, listdir, sched_setaffinity, walk
 
 # Community modules
 
@@ -11,6 +11,7 @@ import gmn
 from   gmn.CLI_Parser   import ParseCmdLine
 from   gmn.ConfigParser import ReadConfig
 
+sched_setaffinity(0, range(cpu_count()))
 #-------------------------------------------
 def CallGenerate( args, param ):
     '''Wrapper for GMN.Generate() in multiprocessing Pool'''

--- a/apps/RunDir.py
+++ b/apps/RunDir.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # Python distribution modules
-from multiprocessing import Pool
+from multiprocessing import set_start_method, Pool
 from os import listdir, walk
 
 # Community modules
@@ -42,6 +42,10 @@ def main():
 
     # Iterable of parameters for each configFile
     params = [ ReadConfig( args, configurationFile = f ) for f in configFiles ]
+
+    # libgomp deadlocks when called in a forked process
+    # c.f. https://github.com/pytorch/pytorch/issues/17199
+    set_start_method( "spawn" )
 
     with Pool( processes = args.cores ) as pool:
         DataOuts = pool.starmap( CallGenerate, [ ( args, param ) for param in params ] )

--- a/gmn/Node.py
+++ b/gmn/Node.py
@@ -17,8 +17,6 @@ except ImportError as err:
 
 try:
     from os import environ # JP Need to query not hardwire
-    environ[ 'OMP_PROC_BIND' ] = 'spread'  # kedm : OpenMP settings
-    environ[ 'OMP_PLACES'    ] = 'threads'
     from kedm import simplex as kedm_simplex
     from kedm import smap    as kedm_smap
 except ImportError as err:


### PR DESCRIPTION
The `RunDir.py` app errors if the node function is unpicklable (i.e. kEDM functions)  since arguments given to`Pool.map` need to be picklable. We can fix this by constructing the GMN object in the task function.